### PR TITLE
Fix Image structure

### DIFF
--- a/images.go
+++ b/images.go
@@ -1,26 +1,11 @@
 package trakttv
 
-// baseImage represents the a generic image
-type baseImage struct {
-	Full   string `json:"full"`
-	Medium string `json:"medium"`
-	Thumb  string `json:"thumb"`
-}
-
-// baseImageFullOnly represents the a generic image with only the full option
-type baseImageFullOnly struct {
-	Full string `json:"full"`
-}
-
 // Images represents the images linked to a video
 type Images struct {
-	Poster     baseImage         `json:"poster"`
-	Fanart     baseImage         `json:"fanart"`
-	Screenshot baseImage         `json:"screenshot"`
-	Headshot   baseImage         `json:"headshot"`
-	Banner     baseImageFullOnly `json:"banner"`
-	Logo       baseImageFullOnly `json:"logo"`
-	Clearart   baseImageFullOnly `json:"clearart"`
-	Thumb      baseImageFullOnly `json:"thumb"`
-	Avatar     baseImageFullOnly `json:"avatar"`
+	Fanart   []string `json:"fanart"`
+	Poster   []string `json:"poster"`
+	Logo     []string `json:"logo"`
+	Clearart []string `json:"clearart"`
+	Banner   []string `json:"banner"`
+	Thumb    []string `json:"thumb"`
 }


### PR DESCRIPTION
https://trakt.docs.apiary.io/#introduction/images/example-images-object

I guess before that, the images were empty, so everything worked. Now that the API returns som images, the unmarshal fails with `json: cannot unmarshal array into Go struct field Images.movie.images.fanart of type trakttv.baseImage`